### PR TITLE
Refactor linked-lists

### DIFF
--- a/linked-lists/lib/linked_list.rb
+++ b/linked-lists/lib/linked_list.rb
@@ -1,96 +1,76 @@
 require_relative 'node'
 
 class LinkedList
-  attr_accessor :node_list
+  attr_accessor :head
 
   def initialize
-    @node_list = []
+    @head = nil
   end
 
   def append(value)
     new_node = Node.new(value)
-    unless self.node_list.empty?
-      self.node_list[-1].next_node = new_node
+    if self.head().nil?
+      self.head = new_node
+    else
+      current_node = self.head()
+      until current_node.next_node.nil?
+        current_node = current_node.next_node
+      end
+      current_node.next_node = new_node
     end
-    self.node_list << new_node
   end
 
   def prepend(value)
     new_node = Node.new(value)
-    unless self.node_list.empty?
-      new_node.next_node = self.node_list[0]
-    end
-    self.node_list.unshift(new_node)
+    new_node.next_node = self.head()
+    self.head = new_node
   end
 
   def size
-    self.node_list.length
+    #TODO
   end
 
   def head
-    self.node_list[0]
+    @head
   end
 
   def tail
-    self.node_list[-1]
+    #TODO
   end
 
   def at(index)
-    self.node_list[index]
+    #TODO
   end
 
   def pop
-    self.pop
-    self.node_list[-1].next_node = nil
+    #TODO
   end
 
   def contains?(value)
-    for node in self.node_list
-      return true if node.value == value
-    end
-    return false
+    #TODO
   end
 
   def find(value)
-    self.node_list.each_with_index { |node, idx| return idx if node.value == value }
-    return nil
+    #TODO
   end
 
   def insert_at(value, index)
-    if index == 0
-      self.prepend(value)
-    elsif index == self.node_list.length - 1
-      self.append(value)
-    elsif index > 0 && index < self.node_list.length
-      new_node = Node.new(value)
-      left_sublist = self.node_list[..index - 1]
-      right_sublist = self.node_list[index..]
-      left_sublist[-1].next_node = new_node
-      new_node.next_node = right_sublist[0]
-      left_sublist << new_node
-      self.node_list = left_sublist + right_sublist
-    end
+    #TODO
   end
 
   def remove_at(index)
-    if index == 0
-      self.node_list.shift
-    elsif index == self.node_list.length - 1
-      self.node_list.pop
-    elsif index > 0 && index < self.node_list.length
-      left_sublist = self.node_list[..index - 1]
-      right_sublist = self.node_list[index + 1..]
-      left_sublist[-1].next_node = right_sublist[0]
-      self.node_list = left_sublist + right_sublist
-    end
+    #TODO
   end
 
   def to_s
     string_representation = ""
-    for node in self.node_list
-      string_representation += "( #{node.value} ) -> "
+
+    current_node = self.head()
+    string_representation += "( #{current_node.value} ) -> "
+    until current_node.next_node.nil?
+      current_node = current_node.next_node
+      string_representation += "( #{current_node.value} ) -> "
     end
     string_representation += "nil"
-    string_representation
   end
 end

--- a/linked-lists/lib/linked_list.rb
+++ b/linked-lists/lib/linked_list.rb
@@ -28,11 +28,11 @@ class LinkedList
 
   def size
     length = 0
-    if self.head.nil?
+    current_node = self.head
+    if current_node.nil?
       length
     else
       length = 1
-      current_node = self.head
       until current_node.next_node.nil?
         length += 1
         current_node = current_node.next_node
@@ -72,15 +72,53 @@ class LinkedList
   end
 
   def pop
-    #TODO
+    if self.size == 0 || self.size == 1
+      self.head = nil
+    else
+      current_node = self.head
+      until current_node.next_node.next_node.nil?
+        current_node = current_node.next_node
+      end
+      current_node.next_node = nil
+    end
   end
 
   def contains?(value)
-    #TODO
+    contained = false
+    current_node = self.head
+    if current_node.nil?
+      return
+    elsif current_node.value == value
+      contained = true
+    else
+      until current_node.next_node.nil?
+        current_node = current_node.next_node
+        if current_node.value == value
+          contained = true
+          return contained
+        end
+      end
+    end
+    contained
   end
 
   def find(value)
-    #TODO
+    idx = 0
+    current_node = self.head
+    if current_node.nil?
+      return nil
+    elsif current_node.value == value
+      return idx
+    else
+      until current_node.next_node.nil?
+        idx += 1
+        current_node = current_node.next_node
+        if current_node.value == value
+          return idx
+        end
+      end
+    end
+    return nil
   end
 
   def insert_at(value, index)

--- a/linked-lists/lib/linked_list.rb
+++ b/linked-lists/lib/linked_list.rb
@@ -122,11 +122,41 @@ class LinkedList
   end
 
   def insert_at(value, index)
-    #TODO
+    new_node = Node.new(value)
+    current_node = self.head
+    previous_node = current_node
+    if index == 0
+      self.prepend(value)
+    elsif index > self.size
+      return
+    else
+      current_idx = 0
+      until current_idx == index
+        current_idx += 1
+        previous_node = current_node
+        current_node = current_node.next_node
+      end
+      new_node.next_node = current_node
+      previous_node.next_node = new_node
+    end
   end
 
   def remove_at(index)
-    #TODO
+    current_node = self.head
+    previous_node = current_node
+    if index == 0
+      self.head = current_node.next_node
+    elsif index >= self.size
+      return
+    else
+      current_idx = 0
+      until current_idx == index
+        current_idx += 1
+        previous_node = current_node
+        current_node = current_node.next_node
+      end
+      previous_node.next_node = current_node.next_node
+    end
   end
 
   def to_s

--- a/linked-lists/lib/linked_list.rb
+++ b/linked-lists/lib/linked_list.rb
@@ -9,10 +9,10 @@ class LinkedList
 
   def append(value)
     new_node = Node.new(value)
-    if self.head().nil?
+    if self.head.nil?
       self.head = new_node
     else
-      current_node = self.head()
+      current_node = self.head
       until current_node.next_node.nil?
         current_node = current_node.next_node
       end
@@ -22,12 +22,23 @@ class LinkedList
 
   def prepend(value)
     new_node = Node.new(value)
-    new_node.next_node = self.head()
+    new_node.next_node = self.head
     self.head = new_node
   end
 
   def size
-    #TODO
+    length = 0
+    if self.head.nil?
+      length
+    else
+      length = 1
+      current_node = self.head
+      until current_node.next_node.nil?
+        length += 1
+        current_node = current_node.next_node
+      end
+    end
+    length
   end
 
   def head
@@ -35,11 +46,29 @@ class LinkedList
   end
 
   def tail
-    #TODO
+    current_node = self.head
+    if current_node.nil? || current_node.next_node.nil?
+      current_node
+    else
+      until current_node.next_node.nil?
+        current_node = current_node.next_node
+      end
+    end
+    current_node
   end
 
   def at(index)
-    #TODO
+    current_node = self.head
+    if index == 0
+      current_node
+    else
+      current_idx = 0
+      until current_idx == index
+        current_idx += 1
+        current_node = current_node.next_node
+      end
+    end
+    current_node
   end
 
   def pop

--- a/linked-lists/main.rb
+++ b/linked-lists/main.rb
@@ -41,7 +41,20 @@ puts list
 puts 'Testing #remove_at'
 list.remove_at(3)
 puts list
+list.remove_at(0)
+puts list
+list.remove_at(10)
+puts list
+list.remove_at(5) 
+puts list
 
 puts 'Testing #insert_at'
 list.insert_at('papagei',3)
+puts list
+list.insert_at('zeroth',0)
+puts list
+list.insert_at('toobig',10)
+puts list
+puts list.size
+list.insert_at('end',7)
 puts list

--- a/linked-lists/main.rb
+++ b/linked-lists/main.rb
@@ -10,7 +10,6 @@ list.append('parrot')
 list.append('hamster')
 list.append('snake')
 list.append('turtle')
-puts list
 
 puts 'Testing #size'
 puts list.size
@@ -25,12 +24,17 @@ p list.at(3).next_node
 puts list.at(3).next_node.value
 
 puts 'Testing #contains?'
-puts list.contains?('cat')
-puts list.contains?('cast')
+puts "contains dog? #{list.contains?('dog')}"
+puts "contains cat? #{list.contains?('cat')}"
+puts "contains cast? #{list.contains?('cast')}"
+puts "contains turtle? #{list.contains?('turtle')}"
 
 puts 'Testing #find'
+puts "Find 'catz': #{list.find('catz')}"
 puts "Find 'cat': #{list.find('cat')}"
+puts "Find 'turtle': #{list.find('turtle')}"
 puts "Find 'cast': #{list.find('cast')}"
+p list.find('cast')
 
 puts list
 

--- a/linked-lists/main.rb
+++ b/linked-lists/main.rb
@@ -3,16 +3,14 @@ require_relative 'lib/linked_list'
 list = LinkedList.new
 
 list.append('dog')
+puts list
 list.prepend('catz')
 list.append('cat')
 list.append('parrot')
 list.append('hamster')
 list.append('snake')
 list.append('turtle')
-
-puts list.node_list[0]
-puts list.node_list[0].next_node
-puts list.node_list[1]
+puts list
 
 puts 'Testing #size'
 puts list.size

--- a/linked-lists/main.rb
+++ b/linked-lists/main.rb
@@ -15,9 +15,13 @@ puts list
 puts 'Testing #size'
 puts list.size
 
+puts  'Testing #tail'
+p list.tail
+
 puts 'Testing #at'
+puts list.at(0).value
 puts list.at(3).value
-puts list.at(3).next_node
+p list.at(3).next_node
 puts list.at(3).next_node.value
 
 puts 'Testing #contains?'


### PR DESCRIPTION
Previous version of linked-lists used an array variable `node_list` to conceptualise the list, and make it easy to prototype the logic.

This refactor removes that array variable and chains the nodes in the linked list properly.